### PR TITLE
Fix #69

### DIFF
--- a/checkout-fees-for-woocommerce/includes/class-alg-wc-checkout-fees.php
+++ b/checkout-fees-for-woocommerce/includes/class-alg-wc-checkout-fees.php
@@ -101,6 +101,9 @@ if ( ! class_exists( 'Alg_WC_Checkout_Fees' ) ) :
 				// Modify Fee HTML.
 				add_filter( 'woocommerce_cart_totals_fee_html', array( $this, 'modify_fee_html_for_taxes' ), 10, 2 );
 
+				// Modify stripe parameters and set payment page as checkout in order to enable Stripe to be initialized.
+				add_filter( 'wc_stripe_params', array( $this, 'modify_stripe_params' ) );
+				
 				// check if subscriptions is enabled.
 				if ( in_array( 'woocommerce-subscriptions/woocommerce-subscriptions.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) ) {
 					// use this hook to add our fees in the recurring total displayed in the cart for subscriptions.
@@ -997,6 +1000,16 @@ if ( ! class_exists( 'Alg_WC_Checkout_Fees' ) ) :
 					wc_add_order_item_meta( $item_id, '_last_added_fee_2', $item->get_name() );
 				}
 			}
+		}
+
+		/**
+		 * Function to modify stripe parameters and set payment page as checkout.
+		 *
+		 * @param array $stripe_params Array of parameters for Stripe payment plugin.
+		 */
+		public function modify_stripe_params( $stripe_params ) {
+			$stripe_params['is_checkout'] = 'yes';
+			return $stripe_params;
 		}
 	}
 

--- a/checkout-fees-for-woocommerce/includes/class-alg-wc-order-fees.php
+++ b/checkout-fees-for-woocommerce/includes/class-alg-wc-order-fees.php
@@ -64,8 +64,8 @@ if ( ! class_exists( 'Alg_WC_Order_Fees' ) ) :
 			global $wp;
 			check_ajax_referer( 'update-payment-method', 'security' );
 
-			$payment_method = isset( $_POST['payment_method'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_method'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-			$order_id       = isset( $_POST['order_id'] ) ? sanitize_key( $_POST['order_id'] ): 0; // phpcs:ignore
+			$payment_method       = isset( $_POST['payment_method'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_method'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+			$order_id             = isset( $_POST['order_id'] ) ? sanitize_key( $_POST['order_id'] ): 0; // phpcs:ignore
 			$payment_method_title = isset( $_POST['payment_method_title'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_method_title'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 
 			if ( $order_id <= 0 ) {
@@ -79,7 +79,7 @@ if ( ! class_exists( 'Alg_WC_Order_Fees' ) ) :
 			// Update payment method record in the database.
 			update_post_meta( $order_id, '_payment_method', $payment_method );
 			update_post_meta( $order_id, '_payment_method_title', $payment_method_title );
-			
+
 			// Declare $order again to fetch updates to post meta and serve to payment templte engine.
 			$order = wc_get_order( $order_id );
 

--- a/checkout-fees-for-woocommerce/includes/class-alg-wc-order-fees.php
+++ b/checkout-fees-for-woocommerce/includes/class-alg-wc-order-fees.php
@@ -66,13 +66,22 @@ if ( ! class_exists( 'Alg_WC_Order_Fees' ) ) :
 
 			$payment_method = isset( $_POST['payment_method'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_method'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 			$order_id       = isset( $_POST['order_id'] ) ? sanitize_key( $_POST['order_id'] ): 0; // phpcs:ignore
+			$payment_method_title = isset( $_POST['payment_method_title'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_method_title'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 
 			if ( $order_id <= 0 ) {
 				wp_die();
 			}
+
 			$order = wc_get_order( $order_id );
 			$this->remove_fees( $order );
 			$this->add_gateways_fees( $order, $payment_method );
+
+			// Update payment method record in the database.
+			update_post_meta( $order_id, '_payment_method', $payment_method );
+			update_post_meta( $order_id, '_payment_method_title', $payment_method_title );
+			
+			// Declare $order again to fetch updates to post meta and serve to payment templte engine.
+			$order = wc_get_order( $order_id );
 
 			ob_start();
 			$this->woocommerce_order_pay( $order );

--- a/checkout-fees-for-woocommerce/includes/js/checkout-fees.js
+++ b/checkout-fees-for-woocommerce/includes/js/checkout-fees.js
@@ -3,6 +3,7 @@
  */
 
 jQuery(($) => {
+
 	const orderPayReferrer = $('input[name="_wp_http_referer"]').val();
 	let referrerArr = '';
   
@@ -10,30 +11,42 @@ jQuery(($) => {
 	  referrerArr = orderPayReferrer.split('/');
 	}
   
-	  $('form#order_review').on('click', 'input[name="payment_method"]', () => {
-	  const order_id = ( pgf_checkout_order_id.order_id ) ? pgf_checkout_order_id.order_id : referrerArr[3];
-	  $('#place_order').prop('disabled', true);
-		  var paymentMethod = $('input[name="payment_method"]:checked').val();
-	  // On visiting Pay for order page, take the payment method which is present in the order.
-	  if ( '' !== pgf_checkout_order_id.payment_method ) {
-		paymentMethod = pgf_checkout_order_id.payment_method;
-	  }
-		  const data          = {
-			  payment_method: paymentMethod,
-			  order_id: order_id,
-			  security: pgf_checkout_params.update_payment_method_nonce
-		  };
-	  // We need to set the payment method blank because when second time when it comes here on changing the payment method it should take that changed value and not the payment method present in the order.
-	  pgf_checkout_order_id.payment_method = '';
-	  $.post('?wc-ajax=update_fees', data, (response) => {
-		$('#place_order').prop('disabled', false);
-		if (response && response.fragments) {
-		  $('#order_review').html(response.fragments);
-		  $(`input[name="payment_method"][value=${paymentMethod}]`).prop('checked', true);
-		  $(`.payment_method_${paymentMethod}`).css('display', 'block');
-		  $(`div.payment_box:not(".payment_method_${paymentMethod}")`).filter(':visible').slideUp(0);
+	$('form#order_review').on('click', 'input[name="payment_method"]', () => {
+
+		const order_id = ( pgf_checkout_order_id.order_id ) ? pgf_checkout_order_id.order_id : referrerArr[3];
+
+		$('#place_order').prop('disabled', true);
+		
+		var paymentMethod = $('input[name="payment_method"]:checked').val();
+
+		// Get Payment Title and strip out all html tags.
+		var paymentMethodTitle = $(`label[for="payment_method_${paymentMethod}"]`).text().replace(/[\t\n]+/g,'').trim();
+
+		// On visiting Pay for order page, take the payment method and payment title which are present in the order.
+		if ( '' !== pgf_checkout_order_id.payment_method ) {
+			paymentMethod = pgf_checkout_order_id.payment_method;
+			paymentMethodTitle = $(`label[for="payment_method_${paymentMethod}"]`).text().replace(/[\t\n]+/g,'').trim();
 		}
-	  });
+
+		const data = {
+			payment_method: paymentMethod,
+			payment_method_title: paymentMethodTitle,
+			order_id: order_id,
+			security: pgf_checkout_params.update_payment_method_nonce
+		};
+
+		// We need to set the payment method blank because when second time when it comes here on changing the payment method it should take that changed value and not the payment method present in the order.
+		pgf_checkout_order_id.payment_method = '';
+		$.post('?wc-ajax=update_fees', data, (response) => {
+			$('#place_order').prop('disabled', false);
+			if (response && response.fragments) {
+				$('#order_review').html(response.fragments);
+				$(`input[name="payment_method"][value=${paymentMethod}]`).prop('checked', true);
+				$(`.payment_method_${paymentMethod}`).css('display', 'block');
+				$(`div.payment_box:not(".payment_method_${paymentMethod}")`).filter(':visible').slideUp(0);
+				$(document.body).trigger('updated_checkout');
+			}
+		});
 	});
 
 	$('body').on('change', 'input[name="payment_method"]', function() {


### PR DESCRIPTION
Fix #69 

The issue was specifically with the Stripe plugin being unusable after the payment method has been selected/changed. The WC Order Page has been tweaked with fixes to allow the Stripe plugin to be re-initialized when the payment option has been changed. Other fixes that were done:

1. Save payment option method and payment title to the database
2. Automatically retrieved saved payment option and payment title and set on page load