### PR TITLE
fix #185

### DIFF
--- a/includes/class-alg-wc-checkout-fees.php
+++ b/includes/class-alg-wc-checkout-fees.php
@@ -470,7 +470,8 @@ if ( ! class_exists( 'Alg_WC_Checkout_Fees' ) ) :
 							);
 					} else {
 							WC()->cart->add_fee( $global_title, $global_fee );
-							$this->fees_added[] = $global_title;
+							$this->fees_added[]   = $global_title;
+							$this->last_fee_added = $global_title;
 					}
 				}
 			}
@@ -487,7 +488,8 @@ if ( ! class_exists( 'Alg_WC_Checkout_Fees' ) ) :
 				}
 				if ( ! empty( $merged_fee ) ) {
 					WC()->cart->add_fee( $merged_fee['title'], $merged_fee['value'], $merged_fee['taxable'], $merged_fee['tax_class'] );
-					$this->fees_added[] = $merged_fee['title'];
+					$this->fees_added[]   = $merged_fee['title'];
+					$this->last_fee_added = $merged_fee['title'];
 				}
 			}
 		}


### PR DESCRIPTION
The PG fees are not removed from the Edit Order Page. I changed the woocommerce_process_shop_order_meta hook and added the woocommerce_before_save_order_items hook to update the order with the updated changes. For testing, check that all updated PG fees are saved in order, and also check that they are updated in the frontend order.

Fix #185