### PR TITLE
Fix-#214

### DIFF
--- a/includes/class-alg-wc-checkout-fees.php
+++ b/includes/class-alg-wc-checkout-fees.php
@@ -978,6 +978,9 @@ if ( ! class_exists( 'Alg_WC_Checkout_Fees' ) ) :
 		 * @since   1.1.0
 		 */
 		public function recheck_fee_title( $fee_text, $fees ) {
+			if ( is_checkout() ) {
+				return $fee_text;
+			}
 			foreach ( $fees as $fee ) {
 				if ( $fee_text === $fee->name ) {
 					$fee_text .= ' #2';


### PR DESCRIPTION
 Fix #214 I have added a check for the checkout page. The issue is when the Woo Discount Rules plugin is activated, the fee is displayed twice on the checkout page.