### PR TITLE
Fixed fatal error is shown when trying to activate our PGBF lite plugin

### DIFF
--- a/checkout-block/checkout-blocks-initialize.php
+++ b/checkout-block/checkout-blocks-initialize.php
@@ -20,7 +20,7 @@ add_action(
         add_action(
             'woocommerce_blocks_checkout_block_registration',
             function ( $integration_registry ) {
-                $integration_registry->register( new Blocks_Integration() );
+                $integration_registry->register( new CheckoutFeesBlocksIntegration() );
             }
         );
 

--- a/checkout-block/class-blocks-integration.php
+++ b/checkout-block/class-blocks-integration.php
@@ -16,7 +16,7 @@ define( 'PGBF_BLOCK_VERSION', '1.0.0' );
 /**
  * Blocks Integration.
  */
-class Blocks_Integration implements IntegrationInterface {
+class CheckoutFeesBlocksIntegration implements IntegrationInterface {
 	/**
 	 * The name of the integration.
 	 *


### PR DESCRIPTION
Fix #238. Changed the name that was causing a conflict with the plugin.