### PR TITLE
Fix #267 Added filter for external fee to include in our fees

### DIFF
--- a/includes/class-alg-wc-checkout-fees.php
+++ b/includes/class-alg-wc-checkout-fees.php
@@ -928,6 +928,15 @@ if ( ! class_exists( 'Alg_WC_Checkout_Fees' ) ) :
 							$total_in_cart     += $tax_total + $shipping_tax_total;
 						}
 					}
+					if ( WC()->cart->get_fees() ) {
+						foreach ( WC()->cart->get_fees() as $fee ) {
+							// Use a filter to allow external modification.
+							$apply_fee = apply_filters( 'external_fee_include_in_gateway_fee', false, $fee );
+							if ( $apply_fee ) {
+								$total_in_cart += $fee->amount;
+							}
+						}
+					}
 					if ( ! empty( WC()->cart->credit_used ) && is_array( WC()->cart->credit_used ) ) { // for "WooCommerce Gift Certificates" plugin.
 						$total_in_cart -= array_sum( WC()->cart->credit_used );
 					}


### PR DESCRIPTION
Fix #267 Added filter for external fee to include in our fees

function WPC_order_tip_fee_include( $include, $fee ) {
	if ( isset( $fee->id ) !== false ) {
		return true; // Include in total.
	}
	return $include;
}
add_action( 'external_fee_include_in_gateway_fee', 'WPC_order_tip_fee_include', 10, 2 );