### PR TITLE
Fix unauthorized order modification in AJAX fee handler

### DIFF
--- a/includes/class-alg-wc-checkout-fees-admin.php
+++ b/includes/class-alg-wc-checkout-fees-admin.php
@@ -94,7 +94,7 @@ if ( ! class_exists( 'Alg_WC_Checkout_Fees_Admin' ) ) :
 		public function maybe_delete_all_plugin_data() {
 			if ( isset( $_GET['alg_woocommerce_checkout_fees_delete_all_data'] ) ) {
 				// Checking nonce & user role.
-				if ( ! isset( $_GET['alg_woocommerce_checkout_fees_delete_all_data_nonce'] ) || ! wp_verify_nonce( $_GET['alg_woocommerce_checkout_fees_delete_all_data_nonce'], 'alg_woocommerce_checkout_fees_delete_all_data' ) || ! current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore
+				if ( ! isset( $_GET['alg_woocommerce_checkout_fees_delete_all_data_nonce'] ) || ! wp_verify_nonce( $_GET['alg_woocommerce_checkout_fees_delete_all_data_nonce'], 'alg_woocommerce_checkout_fees_delete_all_data' ) || ! current_user_can( 'manage_woocommerce' ) || ! current_user_can( 'manage_options' ) ) { // phpcs:ignore
 					add_action( 'admin_notices', array( $this, 'admin_notice_delete_all_plugin_data_error' ) );
 					return;
 				}

--- a/includes/class-alg-wc-order-fees.php
+++ b/includes/class-alg-wc-order-fees.php
@@ -129,10 +129,41 @@ if ( ! class_exists( 'Alg_WC_Order_Fees' ) ) :
 			$payment_method_title = isset( $_POST['payment_method_title'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_method_title'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 
 			if ( $order_id <= 0 ) {
-				wp_die();
+				wp_send_json_error( 'Invalid order ID' );
 			}
 
 			$order = wc_get_order( $order_id );
+
+			if ( ! $order ) {
+				wp_send_json_error( 'Order not found' );
+    		}
+
+		    $current_user_id = get_current_user_id();
+		    $order_user_id   = (int) $order->get_user_id();
+
+		    // Allow admins
+		    if ( current_user_can( 'manage_woocommerce' ) ) {
+		        $authorized = true;
+		    } 
+		    // Allow order owner (logged-in users)
+		    elseif ( $current_user_id && $current_user_id === $order_user_id ) {
+		        $authorized = true;
+		    } 
+		    // Allow guest ONLY if order key matches (order-pay scenario).
+		    elseif ( ! is_user_logged_in() ) {
+		        $posted_order_key = isset( $_POST['order_key'] ) 
+		            ? wc_clean( wp_unslash( $_POST['order_key'] ) ) 
+		            : '';
+
+		        $authorized = hash_equals( $order->get_order_key(), $posted_order_key );
+		    } 
+		    else {
+		        $authorized = false;
+		    }
+
+		    if ( ! $authorized ) {
+		        wp_send_json_error( 'Unauthorized access' );
+		    }
 			if ( $order ) {
 				$add_fees = apply_filters( 'alg_wc_add_gateways_fees', true, $order );
 				$this->remove_fees( $order );


### PR DESCRIPTION
Adds proper authorization and ownership checks to the `wc_ajax_update_fees` handler. Prevents unauthenticated users from modifying arbitrary orders by validating order ownership (or admin capability) and verifying order key for guest users.

Fix #306

Testing instruction:
1. Test fees on order pay page.
2. Test 'Delete all data' functionality.