### PR TITLE
Fix #310 A security issue is reported by the customer.

### DIFF
--- a/includes/class-alg-wc-order-fees.php
+++ b/includes/class-alg-wc-order-fees.php
@@ -133,10 +133,15 @@ if ( ! class_exists( 'Alg_WC_Order_Fees' ) ) :
 			}
 
 			$order = wc_get_order( $order_id );
-			if ( $order ) {
-				$add_fees = apply_filters( 'alg_wc_add_gateways_fees', true, $order );
-				$this->remove_fees( $order );
+
+			// Security check: ensure current user owns the order or can manage orders.
+			if ( ! $order
+				|| ( get_current_user_id() !== $order->get_customer_id()
+					&& ! current_user_can( 'edit_shop_orders' ) ) ) {
+				wp_send_json_error( array( 'message' => 'forbidden' ), 403 );
 			}
+			$add_fees = apply_filters( 'alg_wc_add_gateways_fees', true, $order );
+			$this->remove_fees( $order );
 			if ( $add_fees ) {
 				$this->add_gateways_fees( $order, $payment_method );
 


### PR DESCRIPTION
Fix #310 A security issue is reported by the customer.

Cause - The AJAX function was updating order fees and payment methods without validating whether the current logged-in user owned the order being modified, which allowed authenticated users to update other customers’ orders.

Fix - Added an ownership and capability validation check before modifying the order, ensuring only the order owner or users with `edit_shop_orders` capability can update the order.


above issue is also reported by Patchstack and we already fix it here - [https://github.com/TycheSoftwares/checkout-fees-for-woocommerce/pull/307](url)
