### PR TITLE
Fix #309 payment charges were added multiple times on the Pay for order page when the page was refreshed.

### DIFF
--- a/includes/js/checkout-fees.js
+++ b/includes/js/checkout-fees.js
@@ -3,6 +3,7 @@
  */
 
 jQuery(($) => {
+    let debounceTimer = null;    // To prevent double-firing.
 
 	const orderPayReferrer = $('input[name="_wp_http_referer"]').val();
 	let referrerArr = '';
@@ -10,8 +11,7 @@ jQuery(($) => {
 	if( orderPayReferrer != undefined ) {
 	  referrerArr = orderPayReferrer.split('/');
 	}
-  
-	$('form#order_review').on('click', 'input[name="payment_method"]', () => {
+	const triggerUpdateFees = () => {
 
 		const order_id = ( pgf_checkout_order_id.order_id ) ? pgf_checkout_order_id.order_id : referrerArr[3];
 
@@ -49,6 +49,10 @@ jQuery(($) => {
 				$(document.body).trigger('updated_checkout');
 			}
 		});
+	}
+	$('form#order_review').on('click', 'input[name="payment_method"]', () => {
+		clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(triggerUpdateFees, 150);
 	});
 
 	$('body').on('change', 'input[name="payment_method"]', function() {


### PR DESCRIPTION
Fix #309 payment charges were added multiple times on the Pay for order page when the page was refreshed.

Cause - Multiple `update_fees` AJAX requests were triggered rapidly on the Pay for Order page when the payment method was selected/refreshed, causing the gateway fee to be added multiple times.

Fix - Added a debounce mechanism before triggering the `update_fees` AJAX request to prevent duplicate rapid calls and ensure the gateway fee is applied only once.
