### PR TITLE
Fix #311 Payment gateway fees is not calculated on the deposit amount(Subtotal amount) instead it is calculating on whole total order amount.

### DIFF
--- a/includes/class-alg-wc-checkout-fees.php
+++ b/includes/class-alg-wc-checkout-fees.php
@@ -541,7 +541,18 @@ if ( ! class_exists( 'Alg_WC_Checkout_Fees' ) ) :
 						$_product    = wc_get_product( $args['product_id'] );
 						$sum_for_fee = $_product->get_price() * $args['product_qty'];
 					} else {
-						$sum_for_fee = $total_in_cart;
+						// IF cart has depsoit then use it as base for fee calculation instead of total.
+						$deposit_base  = 0;
+						$deposit_found = false;
+						foreach ( WC()->cart->get_cart() as $_item ) {
+							if ( isset( $_item['deposit_amount'] ) && (float) $_item['deposit_amount'] > 0 ) {
+								$deposit_base += (float) $_item['deposit_amount'] * (int) $_item['quantity'];
+								$deposit_found = true;
+							} else {
+								$deposit_base += (float) $_item['line_total'];
+							}
+						}
+						$sum_for_fee = $deposit_found ? $deposit_base : $total_in_cart;
 					}
 					$new_fee = ( (float) $fee_value / 100 ) * $sum_for_fee;
 					break;


### PR DESCRIPTION
Fix #311 Payment gateway fees is not calculated on the deposit amount(Subtotal amount) instead it is calculating on whole total order amount.

Cause
In calculate_the_fee(), the base for percent type fees was $total_in_cart — which is always the full cart value. When woo-deposit plugin is active and the customer selects a deposit, the fee was incorrectly calculated on the full amount instead of the "Due Today" amount.

Fix
Loop through cart items and check — if an item has deposit_amount, use only that deposit amount as the base for that item, otherwise use the full line_total. This ensures the fee is calculated only on the actually payable amount.