### PR TITLE
Fix #316 The payment gateway fees are not being applied or changed when the Pay for order page is visited in incognito mode..

### DIFF
--- a/includes/class-alg-wc-checkout-fees.php
+++ b/includes/class-alg-wc-checkout-fees.php
@@ -344,6 +344,10 @@ if ( ! class_exists( 'Alg_WC_Checkout_Fees' ) ) :
 				} else {
 					$payment_method = get_post_meta( $order_id, '_payment_method', true );
 				}
+				$order_key = '';
+				if ( isset( $_GET['key'] ) ) { // phpcs:ignore
+					$order_key = wc_clean( wp_unslash( $_GET['key'] ) ); // phpcs:ignore
+				}
 				if ( '' !== get_query_var( 'order-pay' ) ) {
 					wp_localize_script(
 						'alg-payment-gateways-checkout',
@@ -351,6 +355,7 @@ if ( ! class_exists( 'Alg_WC_Checkout_Fees' ) ) :
 						array(
 							'order_id'       => get_query_var( 'order-pay' ),
 							'payment_method' => $payment_method,
+							'order_key'      => $order_key,
 						)
 					);
 				}

--- a/includes/class-alg-wc-order-fees.php
+++ b/includes/class-alg-wc-order-fees.php
@@ -135,35 +135,28 @@ if ( ! class_exists( 'Alg_WC_Order_Fees' ) ) :
 
 			if ( ! $order ) {
 				wp_send_json_error( 'Order not found' );
-    	}
+			}
 
-      $current_user_id = get_current_user_id();
-      $order_user_id   = (int) $order->get_user_id();
+			$current_user_id = get_current_user_id();
+			$order_user_id   = (int) $order->get_user_id();
 
-      // Allow admins
-      if ( current_user_can( 'manage_woocommerce' ) ) {
-          $authorized = true;
-      } 
-      // Allow order owner (logged-in users)
-      elseif ( $current_user_id && $current_user_id === $order_user_id ) {
-          $authorized = true;
-      } 
-      // Allow guest ONLY if order key matches (order-pay scenario).
-      elseif ( ! is_user_logged_in() ) {
-          $posted_order_key = isset( $_POST['order_key'] ) 
-              ? wc_clean( wp_unslash( $_POST['order_key'] ) ) 
-              : '';
+			// Allow admins.
+			if ( current_user_can( 'manage_woocommerce' ) ) {
+				$authorized = true;
+			} elseif ( $current_user_id && $current_user_id === $order_user_id ) {
+				$authorized = true;
+			} elseif ( ! is_user_logged_in() ) {
+				$posted_order_key = isset( $_POST['order_key'] ) ? wc_clean( wp_unslash( $_POST['order_key'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+				$authorized       = hash_equals( $order->get_order_key(), $posted_order_key );
+			} else {
+				$authorized = false;
+			}
 
-          $authorized = hash_equals( $order->get_order_key(), $posted_order_key );
-      } 
-      else {
-          $authorized = false;
-      }
-
-      if ( ! $authorized ) {
-          wp_send_json_error( 'Unauthorized access' );
-      }
-      if ( $order ) {
+			if ( ! $authorized ) {
+				wp_send_json_error( 'Unauthorized access' );
+			}
+			$add_fees = false;
+			if ( $order ) {
 				$add_fees = apply_filters( 'alg_wc_add_gateways_fees', true, $order );
 				$this->remove_fees( $order );
 			}

--- a/includes/js/checkout-fees.js
+++ b/includes/js/checkout-fees.js
@@ -32,6 +32,7 @@ jQuery(($) => {
 			payment_method: paymentMethod,
 			payment_method_title: paymentMethodTitle,
 			order_id: order_id,
+			order_key: pgf_checkout_order_id.order_key || '',
 			security: pgf_checkout_params.update_payment_method_nonce
 		};
 


### PR DESCRIPTION
Fix #316 The payment gateway fees are not being applied or changed when the Pay for order page is visited in incognito mode.

Cause: Guest users on the order-pay page were rejected because the JS never sent order_key in the AJAX payload, making hash_equals() always fail for unauthenticated users.

Fix: Localized order_key from the URL ?key= param via wp_localize_script and included it in the AJAX POST data so the server-side guest authorization check passes correctly.