### PR TITLE
Fix #339 Fatal error on product pages – "WC_Tax not found".

### DIFF
--- a/includes/frontend/class-fees-info.php
+++ b/includes/frontend/class-fees-info.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use TycheSoftwares\PaymentGatewayFees\Lite\Settings;
 use TycheSoftwares\PaymentGatewayFees\Lite\Product_Fees_Helper;
+use WC_Tax;
 
 /**
  * Display fee info on single product pages.


### PR DESCRIPTION
Fix #339 Fatal error on product pages – "WC_Tax not found".

cause - WC_Tax is not used for that file
fix - added use WC_Tax; in that file.

Similar to PRo - https://github.com/TycheSoftwares/checkout-fees-for-woocommerce-pro/pull/537/changes